### PR TITLE
Fix CTD when going into Soundtrack menus - Fixes #52

### DIFF
--- a/biglobby/lua/lib/managers/menu/_contractboxgui.lua
+++ b/biglobby/lua/lib/managers/menu/_contractboxgui.lua
@@ -10,6 +10,10 @@ local orig__ContractBoxGui = {
 function ContractBoxGui:create_contract_box()
 	orig__ContractBoxGui.create_contract_box(self)
 
+	if not managers.network:session() then
+		return
+	end
+	
 	local num_player_slots = BigLobbyGlobals:num_player_slots()
 
 	-- Only code changed was replacing hardcoded 4 with variable num_player_slots

--- a/biglobby/lua/lib/managers/menu/_menucomponentmanager.lua
+++ b/biglobby/lua/lib/managers/menu/_menucomponentmanager.lua
@@ -22,7 +22,7 @@ end
 -- Shows the peer label over character with alpha of 1 if loaded, or 0.4 if still
 -- in a loading/joining state?
 function MenuComponentManager:show_contract_character(state)
-	orig__MenuComponentManager.create_contract_gui(self, state)
+	orig__MenuComponentManager.show_contract_character(self, state)
 
 	local num_player_slots = BigLobbyGlobals:num_player_slots()
 


### PR DESCRIPTION
Fixes CTD when going into soundtrackmenus by cancelling the initialization if the network manager has no session. This behaviour is also found in the original code, but will not avoid the added code from biglobby from being executed.

For some reason, a "Waiting for Server" will appear in the lower right corner when entereing the menu though. But I expect that to be caused by something different.